### PR TITLE
feat: add support for Laravel 12 and move ignore queries to config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
         laravel: ['10.*', '11.*', '12.*']
         stability: [ prefer-stable ]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,20 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2, 8.3 ]
+        laravel: ['10.*', '11.*', '12.*']
         stability: [ prefer-stable ]
-        experimental: [ false ]
         include:
-          - php: 8.3
-            stability: prefer-stable
-            experimental: true
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+        exclude:
+          - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }}
     steps:
@@ -42,14 +50,9 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install dependencies
-        if: "${{ matrix.experimental == false }}"
         run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Install dependencies (experimental)
-        if: "${{ matrix.experimental == true }}"
-        run: |
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --ignore-platform-reqs
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -64,7 +67,6 @@ jobs:
         run: vendor/bin/phpstan analyse
 
       - name: Static analysis with Psalm
-        if: "${{ matrix.experimental == false }}"
         run: vendor/bin/psalm
 
       - name: Coding style PSR12 Check

--- a/baseline.xml
+++ b/baseline.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
-  <file src="vendor/laravel/framework/src/Illuminate/Console/Command.php">
-    <RedundantCast>
-      <code><![CDATA[(string) $this->help]]></code>
-    </RedundantCast>
-  </file>
-</files>

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
   ],
   "require": {
     "php": ">=8.1",
-    "laravel/framework": "^10|^11",
+    "laravel/framework": "^10|^11|^12",
     "nesbot/carbon": "^2.66|^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0",
-    "orchestra/testbench": "^8.0",
-    "vimeo/psalm": "^5.8",
-    "phpstan/phpstan": "^1.10 || ^2.0",
+    "phpunit/phpunit": "^10.5|^11.0|^12.0",
+    "orchestra/testbench": "^8.0|^9.0|^10.0",
+    "vimeo/psalm": "^5.8|^6.0",
+    "phpstan/phpstan": "^1.10|^2.0",
     "squizlabs/php_codesniffer": "^3.7",
     "slevomat/coding-standard": "^8.8"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "laravel/framework": "^10|^11|^12",
-    "nesbot/carbon": "^2.66|^3.0"
+    "laravel/framework": "^10|^11|^12"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5|^11.0|^12.0",

--- a/config/sql-export.php
+++ b/config/sql-export.php
@@ -12,4 +12,19 @@ return [
      * The export tool exports the Laravel migrations to SQL migration in this directory.
      */
     'sql_migrations_path' => env('SQL_EXPORT_SQL_MIGRATIONS_PATH', base_path() . '/database/sql'),
+
+    /**
+     * Queries to be excluded from the export.
+     *
+     * The queries will be excluded from the export if the query starts with one of the strings in this array.
+     */
+    'sql_excluded_queries' => [
+        'select * from information_schema.tables',
+        'select "migration" from "migrations"',
+        'select max("batch") as aggregate from "migrations"',
+        'create table "migrations" (',
+        'insert into "migrations',
+        'select * from "migrations"',
+        'select exists (select 1 from pg_class c, pg_namespace n where n.nspname = \'public\' and c.relname = \'migrations\' and c.relkind in (\'r\', \'p\') and n.oid = c.relnamespace)',
+    ]
 ];

--- a/config/sql-export.php
+++ b/config/sql-export.php
@@ -26,5 +26,6 @@ return [
         'insert into "migrations',
         'select * from "migrations"',
         'select exists (select 1 from pg_class c, pg_namespace n where n.nspname = \'public\' and c.relname = \'migrations\' and c.relkind in (\'r\', \'p\') and n.oid = c.relnamespace)',
+        'select exists (select 1 from pg_class c, pg_namespace n where n.nspname = current_schema() and c.relname = \'migrations\' and c.relkind in (\'r\', \'p\') and n.oid = c.relnamespace)',
     ]
 ];

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,5 +11,8 @@
 >
     <projectFiles>
         <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,7 +7,6 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
-    errorBaseline="baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Services/ExportMigrationService.php
+++ b/src/Services/ExportMigrationService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MinVWS\SqlExporter\Services;
 
-use Carbon\Carbon;
 use Illuminate\Console\View\Components\Error;
 use Illuminate\Console\View\Components\Info;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -12,6 +11,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
 class ExportMigrationService extends Migrator
@@ -172,7 +172,7 @@ class ExportMigrationService extends Migrator
      */
     protected function writeMigrationsFile(string $outputFileName, array $queries): void
     {
-        $dateString = Carbon::now()->format('Y_m_d_His');
+        $dateString = Date::now()->format('Y_m_d_His');
         $filePath = "{$this->sqlMigrationsPath}/{$dateString}_{$outputFileName}.sql";
         if (!file_exists($this->sqlMigrationsPath)) {
             mkdir($this->sqlMigrationsPath, recursive: true);

--- a/src/SqlExporterServiceProvider.php
+++ b/src/SqlExporterServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MinVWS\SqlExporter;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use MinVWS\SqlExporter\Services\ExportMigrationService;
 
@@ -14,16 +15,18 @@ class SqlExporterServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/sql-export.php', 'sql-export');
 
-        $this->app->singleton(ExportMigrationService::class, function ($app) {
+        $this->app->singleton(ExportMigrationService::class, function (Application $app) {
             $repository = $app['migration.repository'];
+            $config = $app['config'];
 
             return new ExportMigrationService(
-                $repository,
-                $app['db'],
-                $app['files'],
-                $app['events'],
-                config('sql-export.laravel_migrations_path'),
-                config('sql-export.sql_migrations_path'),
+                repository: $repository,
+                resolver: $app['db'],
+                files: $app['files'],
+                dispatcher: $app['events'],
+                laravelMigrationsPath: $config->get('sql-export.laravel_migrations_path'),
+                sqlMigrationsPath: $config->get('sql-export.sql_migrations_path'),
+                sqlExcludedQueries: $config->get('sql-export.sql_excluded_queries', [])
             );
         });
     }

--- a/src/SqlExporterServiceProvider.php
+++ b/src/SqlExporterServiceProvider.php
@@ -9,6 +9,7 @@ use MinVWS\SqlExporter\Services\ExportMigrationService;
 
 class SqlExporterServiceProvider extends ServiceProvider
 {
+    #[\Override]
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/sql-export.php', 'sql-export');

--- a/tests/Feature/SqlExportCommandTest.php
+++ b/tests/Feature/SqlExportCommandTest.php
@@ -7,19 +7,12 @@ namespace MinVWS\SqlExporter\Tests\Feature;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
-use Orchestra\Testbench\TestCase;
+use MinVWS\SqlExporter\Tests\TestCase;
 
 class SqlExportCommandTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private $laravelMigrationsPath;
-
-    /**
-     * @var string
-     */
-    private $sqlMigrationsPath;
+    private string $laravelMigrationsPath;
+    private string $sqlMigrationsPath;
 
     public function setUp(): void
     {
@@ -32,29 +25,6 @@ class SqlExportCommandTest extends TestCase
         mkdir($this->sqlMigrationsPath);
         DB::statement('DROP TABLE IF EXISTS "table";');
         DB::statement('DROP TABLE IF EXISTS "migrations";');
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return ['MinVWS\SqlExporter\SqlExporterServiceProvider'];
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver'   => 'pgsql',
-            'host'     => env('DB_HOST', 'localhost'),
-            'port'     => env('DB_PORT', '55322'),
-            'database' => env('DB_DATABASE', 'db_test'),
-            'username' => env('DB_USERNAME', 'postgres'),
-            'password' => env('DB_PASSWORD', 'password'),
-        ]);
     }
 
     public function testSqlExportCommandWhenNoMigrationsRan()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MinVWS\SqlExporter\Tests;
+
+use MinVWS\SqlExporter\SqlExporterServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SqlExporterServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'pgsql',
+            'host'     => env('DB_HOST', 'localhost'),
+            'port'     => env('DB_PORT', '55322'),
+            'database' => env('DB_DATABASE', 'db_test'),
+            'username' => env('DB_USERNAME', 'postgres'),
+            'password' => env('DB_PASSWORD', 'password'),
+        ]);
+    }
+}


### PR DESCRIPTION
- Add support for Laravel 12.
- Run CI tests for PHP 8.4 and multiple Laravel versions.
- Remove Psalm baseline.
- Remove direct dependency on `nesbot/carbon`.
- Move excluded queries to the config file.
- Add TestCase file for tests.
- Add additional ignores for checking if the migrations table exists, these queries are used in the latest Laravel versions.

This is not a breaking change.