### PR TITLE
fix: double semicolon in sql

### DIFF
--- a/src/Services/ExportMigrationService.php
+++ b/src/Services/ExportMigrationService.php
@@ -186,7 +186,7 @@ class ExportMigrationService extends Migrator
             throw new \Exception("Could not open file {$filePath}");
         }
         foreach ($queries as $query) {
-            fwrite($migrationFile, $query['raw_query'] . ";\n\n");
+            fwrite($migrationFile, rtrim($query['raw_query'], ';') . ";\n\n");
         }
         fclose($migrationFile);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MinVWS\SqlExporter\Tests;
 
+use Illuminate\Support\Facades\Schema;
 use MinVWS\SqlExporter\SqlExporterServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -27,5 +28,10 @@ class TestCase extends Orchestra
             'username' => env('DB_USERNAME', 'postgres'),
             'password' => env('DB_PASSWORD', 'password'),
         ]);
+    }
+
+    protected function cleanupDbTables(): void
+    {
+        Schema::dropAllTables();
     }
 }

--- a/tests/fixtures/database/migrations/2025_06_05_100000_laravel_test_third_migration.php
+++ b/tests/fixtures/database/migrations/2025_06_05_100000_laravel_test_third_migration.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('email');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+            $table->softDeletes();
+        });
+
+        DB::statement('CREATE UNIQUE INDEX unique_active_email ON users(email) WHERE deleted_at IS NULL;');
+
+        DB::statement('DROP INDEX unique_active_email');
+
+        DB::statement('CREATE UNIQUE INDEX unique_active_email ON users(email) WHERE deleted_at IS NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/tests/fixtures/database/sql/2025_06_05_100000_third_migration.sql
+++ b/tests/fixtures/database/sql/2025_06_05_100000_third_migration.sql
@@ -1,0 +1,10 @@
+create table "users" ("id" uuid not null, "email" varchar(255) not null, "created_at" timestamp(0) without time zone not null default CURRENT_TIMESTAMP, "updated_at" timestamp(0) without time zone null default CURRENT_TIMESTAMP, "deleted_at" timestamp(0) without time zone null);
+
+alter table "users" add primary key ("id");
+
+CREATE UNIQUE INDEX unique_active_email ON users(email) WHERE deleted_at IS NULL;
+
+DROP INDEX unique_active_email;
+
+CREATE UNIQUE INDEX unique_active_email ON users(email) WHERE deleted_at IS NULL;
+


### PR DESCRIPTION
Fixes #26 

In the [Laravel documentation](https://laravel.com/docs/12.x/database) the DB statements do not end with a semicolon, but in our code we do not want to add an additional semicolon when the query already has a semicolon.